### PR TITLE
貸出一覧画面、貸出登録機能を追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,5 +1,5 @@
 package jp.co.metateam.library.controller;
-
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,6 +9,21 @@ import jp.co.metateam.library.service.AccountService;
 import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
 import lombok.extern.log4j.Log4j2;
+import jp.co.metateam.library.model.RentalManage;
+
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import jakarta.validation.Valid;
+import jp.co.metateam.library.model.RentalManageDto;
+import org.springframework.validation.BindingResult;
+import jp.co.metateam.library.values.RentalStatus;
+import jp.co.metateam.library.model.Stock;
+import jp.co.metateam.library.model.StockDto;
+import jp.co.metateam.library.model.Account;
+import jp.co.metateam.library.model.AccountDto;
+
 
 /**
  * 貸出管理関連クラスß
@@ -41,10 +56,55 @@ public class RentalManageController {
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
 
+        List <RentalManage> rentalManageList = this.rentalManageService.findAll(); 
+        
         // 貸出一覧画面に渡すデータをmodelに追加
 
+        model.addAttribute("rentalManageList", rentalManageList);
+
         // 貸出一覧画面に遷移
-        return "";
+
+        return "rental/index";
     }
+
+    @GetMapping("/rental/add")
+    public String add(Model model) {
+        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
+        List <Stock> stockList = this.stockService.findAll();
+        List <Account> accounts = this.accountService.findAll();
+
+        model.addAttribute("accounts", accounts);
+        model.addAttribute("rentalManageList", rentalManageList);
+        model.addAttribute("stockList",stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+
+        if (!model.containsAttribute("rentalManageDto")) {
+            model.addAttribute("rentalManageDto", new RentalManageDto());
+        }
+
+        return "rental/add";
+    }
+
+
+    @PostMapping("/rental/add")
+    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
+        try {
+            if (result.hasErrors()) {
+                throw new Exception("Validation error.");
+            }
+            // 登録処理
+            this.rentalManageService.save(rentalManageDto);
+
+            return "redirect:/rental/index";
+        } catch (Exception e) {
+            log.error(e.getMessage());
+
+            ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+            ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+
+            return "redirect:/rental/add";
+        }
+    }
+
 
 }


### PR DESCRIPTION
概要
貸出一覧画面、貸出登録機能を追加

テスト追跡
貸出一覧画面表示、貸出登録画面表示、ドロップダウンの内容表示、画面遷移

備考
貸出登録でエラーが起きた際、エラーメッセージと記入した内容をそのまま表示させたいです。
今回変更した内容のファイルは「RentalManageController.java」のみです。